### PR TITLE
Bugfix: Add 'config' target to 'all'. Fixes #17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all install clean cards score js
+.PHONY: all install clean cards score js config
 all: install cards score js
 
 node := ${CURDIR}/node_modules
@@ -44,6 +44,7 @@ ${client_config}: | ${client_config}.default
 	cp $| $@
 ${server_config}: | ${server_config}.default
 	cp $| $@
+config: ${client_config} ${server_config}
 
 run: js ${server_config}
 	node run


### PR DESCRIPTION
Both the client and server config files will be automatically generated
by 'make' if they are not present, instead of the server config file
being generated only by 'make run'.
